### PR TITLE
feat: drop instead of wrap empty sections

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -69,7 +69,7 @@ export function toClassName(name) {
  */
 function wrapSections($sections) {
   $sections.forEach(($div) => {
-    if (!$div.children.length) {
+    if ($div.childNodes.length === 0) {
       // remove empty sections
       $div.remove();
     } else if (!$div.id) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -69,7 +69,10 @@ export function toClassName(name) {
  */
 function wrapSections($sections) {
   $sections.forEach(($div) => {
-    if (!$div.id) {
+    if (!$div.children.length) {
+      // remove empty sections
+      $div.remove();
+    } else if (!$div.id) {
       const $wrapper = document.createElement('div');
       $wrapper.className = 'section-wrapper';
       $div.parentNode.appendChild($wrapper);


### PR DESCRIPTION
I think we should drop empty sections (e.g. left over from a metadata block) to avoid unexpected spacing from margins or paddings.